### PR TITLE
Add Minimal schema

### DIFF
--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -1,0 +1,24 @@
+name: Test Schema
+on:
+    - push
+    - pull_request
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Setup
+        run: |
+            sudo apt update -q
+            sudo apt install -yy python python3-pip
+      -
+        name: Build
+        run: |
+            ./tools/schema-merge.py
+      -
+        name: Validate
+        run: |
+            ./tools/schema-validate.py

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -3,7 +3,7 @@ on:
     - push
     - pull_request
 jobs:
-  publish:
+  schema:
     runs-on: ubuntu-latest
     steps:
       -
@@ -13,7 +13,7 @@ jobs:
         name: Setup
         run: |
             sudo apt update -q
-            sudo apt install -yy python python3-pip
+            sudo apt install -yy python3 python3-pip
       -
         name: Build
         run: |

--- a/schema/assets/all-assets.json
+++ b/schema/assets/all-assets.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+        {
+            "$ref": "#/$defs/assets/precomposition"
+        }
+    ]
+}

--- a/schema/assets/asset.json
+++ b/schema/assets/asset.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Asset",
+    "allOf": [
+        {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "title": "ID",
+                    "description": "Unique identifier used by layers when referencing this asset",
+                    "type": "string",
+                    "default": ""
+                },
+                "nm": {
+                    "title": "Name",
+                    "description": "Human readable name",
+                    "type": "string"
+                }
+            },
+            "required": ["id"]
+        }
+    ]
+}

--- a/schema/assets/precomposition.json
+++ b/schema/assets/precomposition.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Precomposition",
+    "description": "Asset containing a composition that can be referenced by layers.",
+    "allOf": [
+        {
+            "$ref": "#/$defs/assets/asset"
+        },
+        {
+            "$ref": "#/$defs/animation/composition"
+        }
+    ]
+}

--- a/schema/assets/precomposition.json
+++ b/schema/assets/precomposition.json
@@ -8,7 +8,7 @@
             "$ref": "#/$defs/assets/asset"
         },
         {
-            "$ref": "#/$defs/animation/composition"
+            "$ref": "#/$defs/composition/composition"
         }
     ]
 }

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -55,7 +55,7 @@
             "required": ["w", "h", "fr", "op", "ip"]
         },
         {
-            "$ref": "#/$defs/animation/composition"
+            "$ref": "#/$defs/composition/composition"
         }
     ]
 }

--- a/schema/composition/animation.json
+++ b/schema/composition/animation.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Animation",
+    "description": "Top level object, describing the animation",
+    "allOf": [
+        {
+            "$ref": "#/$defs/helpers/visual-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "fr": {
+                    "title": "Framerate",
+                    "description": "Framerate in frames per second",
+                    "type": "number"
+                },
+                "ip": {
+                    "title": "In Point",
+                    "description": "Frame the animation starts at (usually 0)",
+                    "type": "number"
+                },
+                "op": {
+                    "title": "Out Point",
+                    "description": "Frame the animation stops/loops at, which makes this the duration in frames when `ip` is 0",
+                    "type": "number"
+                },
+                "w": {
+                    "title": "Width",
+                    "description": "Width of the animation",
+                    "type": "integer"
+                },
+                "h": {
+                    "title": "Height",
+                    "description": "Height of the animation",
+                    "type": "integer"
+                },
+                "assets": {
+                    "title": "Assets",
+                    "type": "array",
+                    "description": "List of assets that can be referenced by layers",
+                    "items": {
+                        "$ref": "#/$defs/assets/all-assets"
+                    }
+                },
+                "markers": {
+                    "title": "Markers",
+                    "description": "Markers defining named sections of the composition.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/helpers/marker"
+                    }
+                }
+            },
+            "required": ["w", "h", "fr", "op", "ip"]
+        },
+        {
+            "$ref": "#/$defs/animation/composition"
+        }
+    ]
+}

--- a/schema/composition/composition.json
+++ b/schema/composition/composition.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Composition",
+    "description": "An object that contains a list of layers",
+    "properties": {
+        "layers": {
+            "title": "Layers",
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/layers/all-layers"
+            }
+        }
+    },
+    "required": ["layers"]
+}

--- a/schema/constants/fill-rule.json
+++ b/schema/constants/fill-rule.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "title": "Fill Rule",
+    "description": "Rule used to handle multiple shapes rendered with the same fill object",
+    "oneOf": [
+        {
+            "title": "Non Zero",
+            "description": "Everything is colored (You can think of this as an OR)",
+            "const": 1
+        },
+        {
+            "title": "Even Odd",
+            "description": "Colored based on intersections and path direction, can be used to create \"holes\"",
+            "const": 2
+        }
+    ]
+}

--- a/schema/constants/shape-direction.json
+++ b/schema/constants/shape-direction.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "title": "Shape Direction",
+    "description": "Drawing direction of the shape curve, useful for trim path",
+    "oneOf": [
+        {
+            "title": "Normal",
+            "description": "Usually clockwise",
+            "const": 1
+        },
+        {
+            "title": "Reversed",
+            "description": "Usually counter clockwise",
+            "const": 3
+        }
+    ]
+}

--- a/schema/constants/trim-multiple-shapes.json
+++ b/schema/constants/trim-multiple-shapes.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "title": "Trim Multiple Shapes",
+    "description": "How to handle multiple shapes in trim path",
+    "oneOf": [
+        {
+            "title": "Individually",
+            "const": 1
+        },
+        {
+            "title": "Simultaneously",
+            "const": 2
+        }
+    ]
+}

--- a/schema/helpers/bezier.json
+++ b/schema/helpers/bezier.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Bezier",
+    "description": "Cubic polybezier",
+    "properties": {
+        "c": {
+            "title": "Closed",
+            "type": "boolean",
+            "default": false
+        },
+        "i": {
+            "title": "In Tangents",
+            "type": "array",
+            "description": "Array of points, each point is an array of coordinates.\nThese points are along the `in` tangents relative to the corresponding `v`.",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "default": []
+                }
+            }
+        },
+        "o": {
+            "title": "Out Tangents",
+            "type": "array",
+            "description": "Array of points, each point is an array of coordinates.\nThese points are along the `out` tangents relative to the corresponding `v`.",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "default": []
+                }
+            }
+        },
+        "v": {
+            "title": "Vertices",
+            "description": "Array of points, each point is an array of coordinates.\nThese points are along the bezier path",
+            "type": "array",
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "number",
+                    "default": []
+                }
+            }
+        }
+    },
+    "required": ["i", "v", "o"]
+}

--- a/schema/helpers/color.json
+++ b/schema/helpers/color.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+    "title": "Color",
+    "description": "Color as a [r, g, b] array with values in [0, 1]",
+    "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+    },
+    "minItems": 3,
+    "maxItems": 4
+}

--- a/schema/helpers/int-boolean.json
+++ b/schema/helpers/int-boolean.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "integer",
+    "title": "Integer Boolean",
+    "description": "Represents boolean values as an integer. 0 is false, 1 is true.",
+    "default": 0,
+    "examples": [0],
+    "enum": [0, 1],
+    "oneOf": [
+        {
+            "title": "True",
+            "const": 1
+        },
+        {
+            "title": "False",
+            "const": 0
+        }
+    ]
+}

--- a/schema/helpers/marker.json
+++ b/schema/helpers/marker.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Marker",
+    "description": "Defines named portions of the composition.",
+    "properties": {
+        "cm": {
+            "title": "Comment",
+            "type": "string"
+        },
+        "tm": {
+            "title": "Time",
+            "type": "number"
+        },
+        "dr": {
+            "title": "Duration",
+            "type": "number"
+        }
+    }
+}

--- a/schema/helpers/transform.json
+++ b/schema/helpers/transform.json
@@ -9,36 +9,36 @@
                 "a": {
                     "title": "Anchor Point",
                     "description": "Anchor point: a position (relative to its parent) around which transformations are applied (ie: center for rotation / scale)",
-                    "$ref": "#/$defs/animated-properties/position"
+                    "$ref": "#/$defs/properties/position"
                 },
                 "p": {
                     "title": "Position",
                     "description": "Position / Translation",
-                    "$ref": "#/$defs/animated-properties/position"
+                    "$ref": "#/$defs/properties/position"
                 },
                 "r": {
                     "title": "Rotation",
                     "description": "Rotation in degrees, clockwise",
-                    "$ref": "#/$defs/animated-properties/value"
+                    "$ref": "#/$defs/properties/value"
                 },
                 "s": {
                     "title": "Scale",
                     "description": "Scale factor, `[100, 100]` for no scaling",
-                    "$ref": "#/$defs/animated-properties/multi-dimensional"
+                    "$ref": "#/$defs/properties/multi-dimensional"
                 },
                 "o": {
                     "title": "Opacity",
-                    "$ref": "#/$defs/animated-properties/value"
+                    "$ref": "#/$defs/properties/value"
                 },
                 "sk": {
                     "title": "Skew",
                     "description": "Skew amount as an angle in degrees",
-                    "$ref": "#/$defs/animated-properties/value"
+                    "$ref": "#/$defs/properties/value"
                 },
                 "sa": {
                     "title": "Skew Axis",
                     "description": "Direction along which skew is applied, in degrees (`0` skews along the X axis, `90` along the Y axis)",
-                    "$ref": "#/$defs/animated-properties/value"
+                    "$ref": "#/$defs/properties/value"
                 }
             }
         }

--- a/schema/helpers/transform.json
+++ b/schema/helpers/transform.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Transform",
+    "description": "Layer transform",
+    "allOf": [
+        {
+            "properties": {
+                "a": {
+                    "title": "Anchor Point",
+                    "description": "Anchor point: a position (relative to its parent) around which transformations are applied (ie: center for rotation / scale)",
+                    "$ref": "#/$defs/animated-properties/position"
+                },
+                "p": {
+                    "title": "Position",
+                    "description": "Position / Translation",
+                    "$ref": "#/$defs/animated-properties/position"
+                },
+                "r": {
+                    "title": "Rotation",
+                    "description": "Rotation in degrees, clockwise",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "s": {
+                    "title": "Scale",
+                    "description": "Scale factor, `[100, 100]` for no scaling",
+                    "$ref": "#/$defs/animated-properties/multi-dimensional"
+                },
+                "o": {
+                    "title": "Opacity",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "sk": {
+                    "title": "Skew",
+                    "description": "Skew amount as an angle in degrees",
+                    "$ref": "#/$defs/animated-properties/value"
+                },
+                "sa": {
+                    "title": "Skew Axis",
+                    "description": "Direction along which skew is applied, in degrees (`0` skews along the X axis, `90` along the Y axis)",
+                    "$ref": "#/$defs/animated-properties/value"
+                }
+            }
+        }
+    ]
+}

--- a/schema/helpers/visual-object.json
+++ b/schema/helpers/visual-object.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Visual Object",
+    "description": "",
+    "allOf": [
+        {
+            "type": "object",
+            "properties": {
+                "nm": {
+                    "title": "Name",
+                    "description": "Name, as seen from editors and the like",
+                    "type": "string"
+                },
+                "mn": {
+                    "title": "Match Name",
+                    "description": "Match name, used in expressions",
+                    "type": "string"
+                }
+            },
+            "required": []
+        }
+    ]
+}

--- a/schema/helpers/visual-object.json
+++ b/schema/helpers/visual-object.json
@@ -11,11 +11,6 @@
                     "title": "Name",
                     "description": "Name, as seen from editors and the like",
                     "type": "string"
-                },
-                "mn": {
-                    "title": "Match Name",
-                    "description": "Match name, used in expressions",
-                    "type": "string"
                 }
             },
             "required": []

--- a/schema/layers/all-layers.json
+++ b/schema/layers/all-layers.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+        {
+            "$ref": "#/$defs/layers/precomposition-layer"
+        },
+        {
+            "$ref": "#/$defs/layers/null-layer"
+        },
+        {
+            "$ref": "#/$defs/layers/shape-layer"
+        }
+    ]
+}
+

--- a/schema/layers/layer.json
+++ b/schema/layers/layer.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Layer",
+    "description": "",
+    "allOf": [
+        {
+            "$ref": "#/$defs/helpers/visual-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "hd": {
+                    "title": "Hidden",
+                    "description": "Whether the layer is hidden",
+                    "type": "boolean"
+                },
+                "ty": {
+                    "title": "Type",
+                    "description": "Layer Type",
+                    "type": "integer"
+                },
+                "ind": {
+                    "title": "Index",
+                    "type": "integer",
+                    "description": "Index that can be used for parenting and referenced in expressions"
+                },
+                "parent": {
+                    "title": "Parent Index",
+                    "description": "Must be the `ind` property of another layer",
+                    "type": "integer"
+                },
+                "sr": {
+                    "title": "Time Stretch",
+                    "type": "number",
+                    "default": 1
+                },
+                "ip": {
+                    "title": "In Point",
+                    "description": "Frame when the layer becomes visible",
+                    "type": "number"
+                },
+                "op": {
+                    "title": "Out Point",
+                    "description": "Frame when the layer becomes invisible",
+                    "type": "number"
+                },
+                "st": {
+                    "title": "Start Time",
+                    "type": "number",
+                    "default": 0
+                }
+            },
+            "required": ["ty", "st", "ip", "op"]
+        }
+    ]
+}

--- a/schema/layers/null-layer.json
+++ b/schema/layers/null-layer.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Null Layer",
+    "description": "Layer with no data, useful to group layers together",
+    "allOf": [
+        {
+            "$ref": "#/$defs/layers/visual-layer"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Type",
+                    "description": "Layer type",
+                    "type": "integer",
+                    "const": 3
+                }
+            },
+            "required": [
+                "ty"
+            ]
+        }
+    ]
+}

--- a/schema/layers/precomposition-layer.json
+++ b/schema/layers/precomposition-layer.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Precomposition Layer",
+    "description": "Layer that renders a Precomposition asset",
+    "allOf": [
+        {
+            "$ref": "#/$defs/layers/visual-layer"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Type",
+                    "description": "Layer type",
+                    "type": "integer",
+                    "const": 0
+                },
+                "refId": {
+                    "title": "Reference Id",
+                    "description": "ID of the precomp as specified in the assets",
+                    "type": "string"
+                },
+                "w": {
+                    "title": "Width",
+                    "description": "Width of the clipping rect",
+                    "type": "integer"
+                },
+                "h": {
+                    "title": "Height",
+                    "description": "Height of the clipping rect",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "ty", "refId"
+            ]
+        }
+    ]
+}

--- a/schema/layers/shape-layer.json
+++ b/schema/layers/shape-layer.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Shape Layer",
+    "description": "Layer containing Shapes",
+    "allOf": [
+        {
+            "$ref": "#/$defs/layers/visual-layer"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Type",
+                    "description": "Layer type",
+                    "type": "integer",
+                    "const": 4
+                },
+                "shapes": {
+                    "title": "Shapes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/shapes/shape-list"
+                    }
+                }
+            },
+            "required": [
+                "ty", "shapes"
+            ]
+        }
+    ]
+}

--- a/schema/layers/shape-layer.json
+++ b/schema/layers/shape-layer.json
@@ -20,7 +20,7 @@
                     "title": "Shapes",
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/shapes/shape-list"
+                        "$ref": "#/$defs/shapes/all-shapes"
                     }
                 }
             },

--- a/schema/layers/visual-layer.json
+++ b/schema/layers/visual-layer.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Visual Layer",
+    "description": "Layer used to affect visual elements",
+    "allOf": [
+        {
+            "$ref": "#/$defs/layers/layer"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ks": {
+                    "title": "Transform",
+                    "description": "Layer transform",
+                    "$ref": "#/$defs/helpers/transform"
+                },
+                "ao": {
+                    "title": "Auto Orient",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0,
+                    "description": "If 1, The layer will rotate itself to match its animated position path"
+                }
+            },
+            "required": [
+                "ks"
+            ]
+        }
+    ]
+}
+

--- a/schema/properties/base-keyframe.json
+++ b/schema/properties/base-keyframe.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Base Keyframe",
+    "description": "A Keyframes specifies the value at a specific time and the interpolation function to reach the next keyframe.",
+    "allOf": [
+        {
+            "properties": {
+                "t": {
+                    "title": "Time",
+                    "description": "Frame number",
+                    "type": "number",
+                    "default": 0
+                },
+                "h": {
+                    "title": "Hold",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "default": 0
+                }
+            }
+        },
+        {
+            "if": {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "h": { "const": 0  }
+                        }
+                    },
+                    {
+                        "not": {"required": ["h"]}
+                    }
+                ]
+            },
+            "then": {
+                "properties": {
+                    "i": {
+                        "title": "In Tangent",
+                        "description": "Easing tangent going into the next keyframe",
+                        "$ref": "#/$defs/properties/easing-handle"
+                    },
+                    "o": {
+                        "title": "Out Tangent",
+                        "description": "Easing tangent leaving the current keyframe",
+                        "$ref": "#/$defs/properties/easing-handle"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["t"]
+}
+

--- a/schema/properties/color-keyframe.json
+++ b/schema/properties/color-keyframe.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Color Keyframe",
+    "allOf": [
+        {
+            "$ref": "#/$defs/properties/base-keyframe"
+        },
+        {
+            "properties": {
+                "s": {
+                    "title": "Value",
+                    "description": "Value at this keyframe.",
+                    "$ref": "#/$defs/helpers/color"
+                }
+            }
+        }
+    ],
+    "required": ["t", "s"]
+}

--- a/schema/properties/color-keyframe.json
+++ b/schema/properties/color-keyframe.json
@@ -16,5 +16,5 @@
             }
         }
     ],
-    "required": ["t", "s"]
+    "required": ["s"]
 }

--- a/schema/properties/color-value.json
+++ b/schema/properties/color-value.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Color Value",
+    "description": "An animatable property that holds a Color",
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Static value",
+                    "$ref": "#/$defs/helpers/color"
+                }
+            }
+        },
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/color-keyframe"
+                        }
+                    }
+                }
+        }
+    ],
+    "required": ["a", "k"]
+}

--- a/schema/properties/easing-handle.json
+++ b/schema/properties/easing-handle.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Keyframe Easing",
+    "description": "Bezier handle for keyframe interpolation",
+    "properties": {
+        "x": {
+            "title": "X",
+            "description": "Time component:\n0 means start time of the keyframe,\n1 means time of the next keyframe.",
+            "oneOf":[
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number",
+                        "default": 0,
+                        "minimum": 0,
+                        "maximum": 1
+                    },
+                    "minItems": 1
+                },
+                {
+                    "type": "number",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            ]
+        },
+        "y": {
+            "title": "Y",
+            "description": "Value interpolation component:\n0 means start value of the keyframe,\n1 means value at the next keyframe.",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number",
+                        "default": 0,
+                        "minimum": 0,
+                        "maximum": 1
+                    },
+                    "minItems": 1
+                },
+                {
+                    "type": "number",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 1
+                }
+            ]
+        }
+    },
+    "required": ["x", "y"]
+}

--- a/schema/properties/multi-dimensional.json
+++ b/schema/properties/multi-dimensional.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Multi Dimensional",
+    "description": "An animatable property that holds an array of numbers",
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Static value",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/vector-keyframe"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["a", "k"]
+}

--- a/schema/properties/position-keyframe.json
+++ b/schema/properties/position-keyframe.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "title": "Vector Keyframe",
+    "title": "Position Keyframe",
     "allOf": [
         {
             "$ref": "#/$defs/properties/vector-keyframe"

--- a/schema/properties/position-keyframe.json
+++ b/schema/properties/position-keyframe.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Vector Keyframe",
+    "allOf": [
+        {
+            "$ref": "#/$defs/properties/vector-keyframe"
+        },
+        {
+            "properties": {
+                "ti": {
+                    "title": "Value In Tangent",
+                    "description": "Tangent for values (eg: moving position around a curved path)",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "to": {
+                    "title": "Value Out Tangent",
+                    "description": "Tangent for values (eg: moving position around a curved path)",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/schema/properties/position.json
+++ b/schema/properties/position.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Position Property",
+    "description": "An animatable property to represent a position in space",
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Static value",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        },
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/position-keyframe"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["a", "k"]
+}

--- a/schema/properties/shape-keyframe.json
+++ b/schema/properties/shape-keyframe.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "title": "Vector Keyframe",
+    "title": "Shape Keyframe",
     "allOf": [
         {
             "$ref": "#/$defs/properties/base-keyframe"
@@ -16,5 +16,5 @@
             }
         }
     ],
-    "required": ["t", "s"]
+    "required": ["s"]
 }

--- a/schema/properties/shape-keyframe.json
+++ b/schema/properties/shape-keyframe.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Vector Keyframe",
+    "allOf": [
+        {
+            "$ref": "#/$defs/properties/base-keyframe"
+        },
+        {
+            "properties": {
+                "s": {
+                    "title": "Value",
+                    "description": "Value at this keyframe.",
+                    "$ref": "#/$defs/helpers/bezier"
+                }
+            }
+        }
+    ],
+    "required": ["t", "s"]
+}

--- a/schema/properties/shape-property.json
+++ b/schema/properties/shape-property.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Shape Property",
+    "description": "An animatable property that holds a Bezier shape",
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Static value",
+                    "$ref": "#/$defs/helpers/bezier"
+                }
+            }
+        },
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/shape-keyframe"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["a", "k"]
+}

--- a/schema/properties/value.json
+++ b/schema/properties/value.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Value",
+    "description": "An animatable property that holds a float",
+    "oneOf": [
+        {
+            "$comment": "Not animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 0
+                },
+                "k": {
+                    "title": "Static value",
+                    "type": "number"
+                }
+            }
+        },
+        {
+            "$comment": "Animated",
+            "properties": {
+                "a": {
+                    "title": "Animated",
+                    "description": "Whether the property is animated",
+                    "$ref": "#/$defs/helpers/int-boolean",
+                    "const": 1
+                },
+                "k": {
+                    "type": "array",
+                    "title": "Keyframes",
+                    "description": "Array of keyframes",
+                    "items": {
+                            "$ref": "#/$defs/properties/vector-keyframe"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["a", "k"]
+}

--- a/schema/properties/vector-keyframe.json
+++ b/schema/properties/vector-keyframe.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Vector Keyframe",
+    "allOf": [
+        {
+            "$ref": "#/$defs/properties/base-keyframe"
+        },
+        {
+            "properties": {
+                "s": {
+                    "title": "Value",
+                    "description": "Value at this keyframe.",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            }
+        }
+    ],
+    "required": ["t", "s"]
+}

--- a/schema/properties/vector-keyframe.json
+++ b/schema/properties/vector-keyframe.json
@@ -19,5 +19,5 @@
             }
         }
     ],
-    "required": ["t", "s"]
+    "required": ["s"]
 }

--- a/schema/root.json
+++ b/schema/root.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/lottie-animation-community/lottie-spec/schema/",
+    "$ref": "#/$defs/composition/animation"
+}

--- a/schema/shapes/all-shapes.json
+++ b/schema/shapes/all-shapes.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$comment": "List of valid shapes",
+    "oneOf": [
+        {"$ref": "#/$defs/shapes/ellipse"},
+        {"$ref": "#/$defs/shapes/fill"},
+        {"$ref": "#/$defs/shapes/group"},
+        {"$ref": "#/$defs/shapes/path"},
+        {"$ref": "#/$defs/shapes/rectangle"},
+        {"$ref": "#/$defs/shapes/transform"},
+        {"$ref": "#/$defs/shapes/trim-path"}
+    ]
+}

--- a/schema/shapes/ellipse.json
+++ b/schema/shapes/ellipse.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Ellipse",
+    "description": "Ellipse shape",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "el"
+                },
+                "p": {
+                    "title": "Position",
+                    "$ref": "#/$defs/properties/position"
+                },
+                "s": {
+                    "title": "Size",
+                    "$ref": "#/$defs/properties/multi-dimensional"
+                }
+            },
+            "required": [
+                "ty", "s", "p"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/fill.json
+++ b/schema/shapes/fill.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Fill",
+    "description": "Solid fill color",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-style"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "fl"
+                },
+                "c": {
+                    "title": "Color",
+                    "$ref": "#/$defs/properties/color-value"
+                },
+                "r": {
+                    "title": "Fill Rule",
+                    "$ref": "#/$defs/constants/fill-rule"
+                }
+            },
+            "required": [
+                "ty", "c"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/group.json
+++ b/schema/shapes/group.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Group",
+    "description": "Shape Element that can contain other shapes",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-element"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "gr"
+                },
+                "np": {
+                    "title": "Number Of Properties",
+                    "type": "number"
+                },
+                "it": {
+                    "title": "Shapes",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/shapes/shape-list"
+                    }
+                }
+            },
+            "required": [
+                "ty"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/group.json
+++ b/schema/shapes/group.json
@@ -23,7 +23,7 @@
                     "title": "Shapes",
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/shapes/shape-list"
+                        "$ref": "#/$defs/shapes/all-shapes"
                     }
                 }
             },

--- a/schema/shapes/modifier.json
+++ b/schema/shapes/modifier.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Modifier",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-element"
+        }
+    ]
+}

--- a/schema/shapes/path.json
+++ b/schema/shapes/path.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Path",
+    "description": "Animatable Bezier curve",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "sh"
+                },
+                "ks": {
+                    "title": "Shape",
+                    "description": "Bezier path",
+                    "$ref": "#/$defs/properties/shape-property"
+                }
+            },
+            "required": [
+                "ty", "ks"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/rectangle.json
+++ b/schema/shapes/rectangle.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Rectangle",
+    "description": "A simple rectangle shape",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "rc"
+                },
+                "p": {
+                    "title": "Position",
+                    "description": "Center of the rectangle",
+                    "$ref": "#/$defs/properties/position"
+                },
+                "s": {
+                    "title": "Size",
+                    "$ref": "#/$defs/properties/multi-dimensional"
+                },
+                "r": {
+                    "title": "Rounded",
+                    "description": "Rounded corners radius",
+                    "$ref": "#/$defs/properties/value"
+                }
+            },
+            "required": [
+                "ty", "s", "p"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/shape-element.json
+++ b/schema/shapes/shape-element.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Shape Element",
+    "description": "Base class for all elements of ShapeLayer and Group",
+    "allOf": [
+        {
+            "$ref": "#/$defs/helpers/visual-object"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "hd": {
+                    "title": "Hidden",
+                    "description": "Whether the shape is hidden",
+                    "type": "boolean"
+                },
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string"
+                }
+            },
+            "required": ["ty"]
+        }
+    ]
+}

--- a/schema/shapes/shape-style.json
+++ b/schema/shapes/shape-style.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Shape Style",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-element"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "o": {
+                    "title": "Opacity",
+                    "description": "Opacity, 100 means fully opaque",
+                    "$ref": "#/$defs/properties/value"
+                }
+            },
+            "required": [
+                "o"
+            ]
+        }
+    ]
+}
+

--- a/schema/shapes/shape.json
+++ b/schema/shapes/shape.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Shape",
+    "description": "Drawable shape",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-element"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "d": {
+                    "title": "Direction",
+                    "description": "Direction the shape is drawn as, mostly relevant when using trim path",
+                    "$ref": "#/$defs/constants/shape-direction"
+                }
+            }
+        }
+    ]
+}

--- a/schema/shapes/transform.json
+++ b/schema/shapes/transform.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Transform Shape",
+    "description": "Group transform",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/shape-element"
+        },
+        {
+            "$ref": "#/$defs/helpers/transform"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "tr"
+                }
+            },
+            "required": [
+                "ty"
+            ]
+        }
+    ]
+}

--- a/schema/shapes/trim-path.json
+++ b/schema/shapes/trim-path.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "title": "Trim Path",
+    "description": "Trims shapes into a segment",
+    "allOf": [
+        {
+            "$ref": "#/$defs/shapes/modifier"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ty": {
+                    "title": "Shape Type",
+                    "type": "string",
+                    "const": "tm"
+                },
+                "s": {
+                    "title": "Start",
+                    "description": "Segment start",
+                    "$ref": "#/$defs/properties/value"
+                },
+                "e": {
+                    "title": "End",
+                    "description": "Segment end",
+                    "$ref": "#/$defs/properties/value"
+                },
+                "o": {
+                    "title": "Offset",
+                    "$ref": "#/$defs/properties/value"
+                },
+                "m": {
+                    "title": "Multiple",
+                    "description": "How to treat multiple copies",
+                    "$ref": "#/$defs/constants/trim-multiple-shapes"
+                }
+            },
+            "required": [
+                "ty", "o", "s", "e"
+            ]
+        }
+    ]
+}

--- a/tools/schema-merge.py
+++ b/tools/schema-merge.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import os
+import json
+import pathlib
+import argparse
+
+
+def join_parts(
+    json_data: dict,
+    path: pathlib.Path,
+    exclude: pathlib.Path
+):
+    defs = {}
+    for subdir in sorted(path.iterdir()):
+        dir_schema = {}
+        if subdir.is_dir():
+            for file_item in subdir.iterdir():
+                if file_item.is_file() and file_item.suffix == ".json" and file_item != exclude:
+                    with open(file_item, "r") as file:
+                        try:
+                            file_schema = json.load(file)
+                        except Exception:
+                            print(file_item)
+                            raise
+                    file_schema.pop("$schema", None)
+                    dir_schema[file_item.stem] = file_schema
+            defs[subdir.name] = dir_schema
+
+    json_data["$defs"] = defs
+
+    return json_data
+
+
+root = pathlib.Path(__file__).absolute().parent.parent
+
+parser = argparse.ArgumentParser(description="Joins JSON schema in a single file")
+parser.add_argument(
+    "--input", "-i",
+    type=pathlib.Path,
+    default=root / "schema",
+    help="Path to the input schema files"
+)
+parser.add_argument(
+    "--root", "-r",
+    type=pathlib.Path,
+    default="root.json",
+    help="Root schema file"
+)
+parser.add_argument(
+    "--output", "-o",
+    type=pathlib.Path,
+    default=root / "docs" / "lottie.schema.json",
+    help="Output file name"
+)
+
+args = parser.parse_args()
+input_dir: pathlib.Path = args.input.resolve()
+output_path: pathlib.Path = args.output
+root_path: pathlib.Path = (input_dir / args.root).resolve()
+
+with open(root_path) as file:
+    json_data = json.load(file)
+
+join_parts(json_data, input_dir, root_path)
+
+os.makedirs(output_path.parent, exist_ok=True)
+
+with open(output_path, "w") as file:
+    json.dump(json_data, file, indent=4)

--- a/tools/schema-validate.py
+++ b/tools/schema-validate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import pathlib
+import argparse
+
+from schema_tools.schema import SchemaPath, Schema
+
+
+class Validator:
+    def __init__(self):
+        self.valid_refs = set()
+        self.expected_refs = set()
+        self.has_error = False
+        self.root = None
+
+    def validate(self, schema_root):
+        self.root = Schema(schema_root, None)
+        self.collect_defs(self.root / "$defs")
+        self.validate_recursive(self.root)
+        for unused in (self.expected_refs - self.valid_refs):
+            self.show_error("Unused def: %s" % unused)
+
+    def show_error(self, msg):
+        self.has_error = True
+        print(msg)
+
+    def error(self, schema: Schema, message):
+        self.show_error("%s: %s" % (schema.path, message))
+
+    def validate_ref(self, schema: Schema):
+        if schema.value in self.valid_refs:
+            return
+
+        if SchemaPath(schema.value).walk(self.root) is None:
+            self.error(schema, "Invalid $ref: %s" % schema.value)
+            return
+
+        self.valid_refs.add(schema.value)
+
+    def validate_schema(self, schema: Schema):
+        if "type" in schema:
+            type = schema["type"]
+            if type not in ("object", "array", "number", "integer", "boolean", "string"):
+                self.error(schema, "Unknown type: %s" % type)
+        if "$ref" in schema:
+            self.validate_ref(schema / "$ref")
+
+    def validate_recursive(self, schema: Schema):
+        self.validate_schema(schema)
+        for child in schema:
+            self.validate_recursive(child)
+
+    def collect_defs(self, schema):
+        for child in schema:
+            if "type" in child:
+                self.expected_refs.add(str(child.path))
+            else:
+                self.collect_defs(child)
+
+
+if __name__ == "__main__":
+    root = pathlib.Path(__file__).absolute().parent.parent
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--schema",
+        help="Schema file to validate",
+        type=pathlib.Path,
+        default=root / "docs" / "lottie.schema.json"
+    )
+    args = parser.parse_args()
+
+    with open(args.schema) as file:
+        data = json.load(file)
+
+    validator = Validator()
+    validator.validate(data)
+
+    if validator.has_error:
+        sys.exit(1)
+

--- a/tools/schema_tools/schema.py
+++ b/tools/schema_tools/schema.py
@@ -1,0 +1,98 @@
+import json
+import pathlib
+
+
+class SchemaPath:
+    """
+    Path inside a Schema object
+    """
+    def __init__(self, path=None):
+        if isinstance(path, str):
+            self.chunks = path.strip("#/").split("/")
+        elif path is None:
+            self.chunks = []
+        elif isinstance(path, SchemaPath):
+            self.chunks = list(path.chunks)
+        else:
+            self.chunks = list(path)
+
+    def __itruediv__(self, chunk):
+        self.chunks.append(chunk)
+
+    def __truediv__(self, chunk):
+        return SchemaPath(self.chunks + [chunk])
+
+    def walk(self, schema):
+        for chunk in self.chunks:
+            if not self.valid_step(schema, chunk):
+                return None
+            schema = self.step(schema, chunk)
+        return schema
+
+    @classmethod
+    def step(cls, schema, chunk):
+        return schema[chunk]
+
+    @classmethod
+    def valid_step(cls, schema, chunk):
+        if isinstance(chunk, int) and (not isinstance(schema, list) or len(schema) <= chunk):
+            return False
+        elif chunk not in schema:
+            return False
+        return True
+
+    def __str__(self):
+        return "#/" + "/".join(map(str, self.chunks))
+
+
+class Schema:
+    """
+    Class to access data from a JSON schema
+    """
+    def __init__(self, schema, path=None):
+        self.schema = schema
+        self.path = SchemaPath(path)
+
+    def __getitem__(self, key):
+        return self.child(key).value
+
+    def __truediv__(self, key):
+        return self.child(key)
+
+    def __contains__(self, item):
+        return isinstance(self.schema, dict) and item in self.schema
+
+    def get(self, key, default=None):
+        return self.schema.get(key, default) if isinstance(self.schema, dict) else default
+
+    @property
+    def value(self):
+        return self.schema
+
+    def __iter__(self):
+        if isinstance(self.schema, list):
+            iter = enumerate(self.schema)
+        elif isinstance(self.schema, dict):
+            iter = self.schema.items()
+        else:
+            return
+
+        for key, value in iter:
+            if isinstance(value, (object, list)):
+                yield self / key
+
+    def get_ref(self, path):
+        path = SchemaPath(path)
+        obj = path.walk(self)
+        if obj is None:
+            raise Exception("Schema object %s not found" % path)
+        return Schema(obj, path)
+
+    def items(self):
+        if isinstance(self.schema, dict):
+            for k, v in self.schema.items():
+                yield k, Schema(v, self.path / k)
+        return None
+
+    def child(self, key):
+        return Schema(SchemaPath.step(self.schema, key), self.path / key)


### PR DESCRIPTION
## Description

This adds the schema for a very basic lottie definition (Subset of the baseline profile). 

Once this is merged we can discuss adding schema definitions for more objects in baseline/core profiles.

I've made some of the schema definitions hierarchical so it can map better to an object model (not just JSON validation), this also reduces duplication of certain properties shared by similar objects.

## Compatibility Considerations

I've only added objects and properties that are widely supported. Do let me know if there's anything that should be removed or properties that need to be marked as required for a specific object.